### PR TITLE
Configurable checkout success page url

### DIFF
--- a/src/app/code/community/Allopass/Hipay/Controller/Payment.php
+++ b/src/app/code/community/Allopass/Hipay/Controller/Payment.php
@@ -95,7 +95,7 @@ class Allopass_Hipay_Controller_Payment extends Mage_Core_Controller_Front_Actio
 			$this->processResponse();
 		}*/
 		$this->processResponse();
-		$this->_redirect('checkout/onepage/success');
+		$this->_redirect(Mage::helper('hipay')->getCheckoutSuccessPage($this->getOrder()->getPayment()));
 		
 		return $this;
 	}

--- a/src/app/code/community/Allopass/Hipay/Helper/Data.php
+++ b/src/app/code/community/Allopass/Hipay/Helper/Data.php
@@ -613,7 +613,6 @@ class Allopass_Hipay_Helper_Data extends Mage_Core_Helper_Abstract
 	 * @return string
 	 */
 	public function getCheckoutSuccessPage($payment) {
-		Oe_Func::dump($payment->getMethod());
 		return is_null(Mage::getStoreConfig('payment/'.$payment->getMethod().'/success_redirect_page')) ?
 			'checkout/onepage/success' :
 			Mage::getStoreConfig('payment/'.$payment->getMethod().'/success_redirect_page');

--- a/src/app/code/community/Allopass/Hipay/Helper/Data.php
+++ b/src/app/code/community/Allopass/Hipay/Helper/Data.php
@@ -607,5 +607,17 @@ class Allopass_Hipay_Helper_Data extends Mage_Core_Helper_Abstract
 		return $params;
 	}
 
+	/**
+	 * @param Mage_Sales_Model_Order_Payment $payment
+	 *
+	 * @return string
+	 */
+	public function getCheckoutSuccessPage($payment) {
+		Oe_Func::dump($payment->getMethod());
+		return is_null(Mage::getStoreConfig('payment/'.$payment->getMethod().'/success_redirect_page')) ?
+			'checkout/onepage/success' :
+			Mage::getStoreConfig('payment/'.$payment->getMethod().'/success_redirect_page');
+	}
+
 
 }

--- a/src/app/code/community/Allopass/Hipay/Model/Method/Abstract.php
+++ b/src/app/code/community/Allopass/Hipay/Model/Method/Abstract.php
@@ -859,7 +859,7 @@ abstract class Allopass_Hipay_Model_Method_Abstract extends Mage_Payment_Model_M
 		switch ($gatewayResponse->getState())
 		{
 			case self::STATE_COMPLETED:
-				return $this->isAdmin() ? $urlAdmin : Mage::getUrl('checkout/onepage/success');
+				return $this->isAdmin() ? $urlAdmin : Mage::helper('hipay')->getCheckoutSuccessPage($payment);
 	
 			case self::STATE_FORWARDING:
 				$payment->setIsTransactionPending(1);

--- a/src/app/code/community/Allopass/Hipay/etc/system.xml
+++ b/src/app/code/community/Allopass/Hipay/etc/system.xml
@@ -3629,15 +3629,6 @@
                         </hipay_status_validate_order>
                         <success_redirect_page translate="label">
                             <label>Redirect page success</label>
-                            <comment>Page to redirect when transaction is successful</comment>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>26</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
-                        </success_redirect_page>
-                        <success_redirect_page translate="label">
-                            <label>Redirect page success</label>
                             <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
                             <frontend_type>text</frontend_type>
                             <sort_order>26</sort_order>

--- a/src/app/code/community/Allopass/Hipay/etc/system.xml
+++ b/src/app/code/community/Allopass/Hipay/etc/system.xml
@@ -350,6 +350,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                         <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -638,6 +647,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                         <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -889,6 +907,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -1226,6 +1253,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -1526,6 +1562,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -1708,6 +1753,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -1890,6 +1944,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -2436,6 +2499,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -2618,6 +2690,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -2800,6 +2881,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -2982,6 +3072,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -3164,6 +3263,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -3346,6 +3454,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -3510,7 +3627,25 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
-                         <pending_redirect_page translate="label">
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
+                        <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
                             <frontend_type>select</frontend_type>
@@ -3674,6 +3809,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -3838,6 +3982,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                         <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -4020,6 +4173,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>
@@ -4184,6 +4346,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </hipay_status_validate_order>
+                        <success_redirect_page translate="label">
+                            <label>Redirect page success</label>
+                            <comment>Page to redirect when transaction is successful, leave empty for checkout/onepage/success</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>26</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </success_redirect_page>
                          <pending_redirect_page translate="label">
                             <label>Redirect page pending status</label>
                             <comment>Page to redirect when transaction is in pending status</comment>


### PR DESCRIPTION
Hi there,

This is a feature to be able to configure checkout success page for each hipay payment mode.
We had to develop this because we use a custom checkout and not the default onepage, so success page url isn't "checkout/onepage/success".