### PR TITLE
Check if order payment is available before using it

### DIFF
--- a/src/app/code/community/Allopass/Hipay/Model/Observer.php
+++ b/src/app/code/community/Allopass/Hipay/Model/Observer.php
@@ -183,7 +183,7 @@ class Allopass_Hipay_Model_Observer
 			$order->setForcedCanCreditmemo(false);
 			$order->setForcedCanCreditmemoFromHipay(true);
 		}
-		elseif($order->getPayment()->getMethod() == 'hipay_cc' && strtolower($order->getPayment()->getCcType()) == 'bcmc')
+		elseif($order->getPayment() && $order->getPayment()->getMethod() == 'hipay_cc' && strtolower($order->getPayment()->getCcType()) == 'bcmc')
 		{
 			$order->setForcedCanCreditmemo(false);
 			$order->setForcedCanCreditmemoFromHipay(true);


### PR DESCRIPTION
I think this is a regression from previous version, we had some server errors when trying to load an order by its incrementId if the incrementId doesn't exist in DB.

This happened when using Xtento Tracking Number Import module for instance.
