### PR TITLE
Ensures that all setup scripts can also be executed together with the magento core setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 .idea
 web
 data
+!src/app/code/community/Allopass/Hipay/data
 bin/conf/development/hipay.env
 bin/tests/result.xml
 bin/tests/errors/*

--- a/src/app/code/community/Allopass/Hipay/data/allopass_hipay_setup/data-install-0.1.0.php
+++ b/src/app/code/community/Allopass/Hipay/data/allopass_hipay_setup/data-install-0.1.0.php
@@ -1,0 +1,44 @@
+<?php
+
+$installer = $this;
+
+$installer->startSetup();
+
+$currentVersion = Mage::getVersion();
+if (version_compare($currentVersion, '1.4.2') == 1) {
+
+    $statusTable = $installer->getTable('sales/order_status');
+    $statusStateTable = $installer->getTable('sales/order_status_state');
+    $statusLabelTable = $installer->getTable('sales/order_status_label');
+
+    $status = 'pending_capture';
+    $label = 'Pending Capture';
+    $code = "processing";
+
+    //Insert new Status in DB
+    $data[0] = array(
+        'status' => $status,
+        'label' => $label,
+    );
+
+    try {
+        $installer->getConnection()->insertArray($statusTable, array('status', 'label'), $data);
+        //Insert relation between state and status
+        $data[0] = array(
+            'status' => $status,
+            'state' => $code,
+            'is_default' => 0,
+        );
+
+        $installer->getConnection()->insertArray(
+            $statusStateTable,
+            array('status', 'state', 'is_default'),
+            $data
+        );
+    } catch (Exception $ex) {
+        //Most likely integrity constraint violation. May happen if all setup scripts are run together (including the
+        //ones in the Magento core) on a Magento version at least equal to 1.6.0
+    }
+}
+
+$installer->endSetup();

--- a/src/app/code/community/Allopass/Hipay/data/allopass_hipay_setup/data-upgrade-0.1.2-0.1.3.php
+++ b/src/app/code/community/Allopass/Hipay/data/allopass_hipay_setup/data-upgrade-0.1.2-0.1.3.php
@@ -1,0 +1,68 @@
+<?php
+
+$installer = $this;
+
+$installer->startSetup();
+
+$currentVersion = Mage::getVersion();
+if (version_compare($currentVersion, '1.4.2') == 1) {
+
+    $statusTable = $installer->getTable('sales/order_status');
+    $statusStateTable = $installer->getTable('sales/order_status_state');
+    $statusLabelTable = $installer->getTable('sales/order_status_label');
+
+    $status = 'capture_requested';
+    $label = 'Capture Requested';
+    $code = "processing";
+
+    //Insert new Status in DB
+    $data[0] = array(
+        'status' => $status,
+        'label' => $label,
+    );
+
+    try {
+        $installer->getConnection()->insertArray($statusTable, array('status', 'label'), $data);
+        //Insert relation between state and status
+        $data[0] = array(
+            'status' => $status,
+            'state' => $code,
+            'is_default' => 0,
+        );
+
+        $installer->getConnection()->insertArray(
+            $statusStateTable,
+            array('status', 'state', 'is_default'),
+            $data
+        );
+
+        $status = 'refund_requested';
+        $label = 'Refund Requested';
+        $code = "processing";
+
+        //Insert new Status in DB
+        $data[0] = array(
+            'status' => $status,
+            'label' => $label,
+        );
+
+        $installer->getConnection()->insertArray($statusTable, array('status', 'label'), $data);
+        //Insert relation between state and status
+        $data[0] = array(
+            'status' => $status,
+            'state' => $code,
+            'is_default' => 0,
+        );
+
+        $installer->getConnection()->insertArray(
+            $statusStateTable,
+            array('status', 'state', 'is_default'),
+            $data
+        );
+    } catch (Exception $ex) {
+        //Most likely integrity constraint violation. May happen if all setup scripts are run together (including the
+        //ones in the Magento core) on a Magento version at least equal to 1.6.0
+    }
+}
+
+$installer->endSetup();

--- a/src/app/code/community/Allopass/Hipay/data/allopass_hipay_setup/data-upgrade-1.0.9-1.1.0.php
+++ b/src/app/code/community/Allopass/Hipay/data/allopass_hipay_setup/data-upgrade-1.0.9-1.1.0.php
@@ -1,0 +1,70 @@
+<?php
+
+$installer = $this;
+
+$installer->startSetup();
+
+$currentVersion = Mage::getVersion();
+if (version_compare($currentVersion, '1.4.2') == 1) {
+
+    $statusTable = $installer->getTable('sales/order_status');
+    $statusStateTable = $installer->getTable('sales/order_status_state');
+    $statusLabelTable = $installer->getTable('sales/order_status_label');
+
+    $statues = array(
+        'authorization_requested' =>
+            array(
+                'label' => 'Authorization Requested',
+                'code' => 'processing',
+                'is_default' => 0
+            ),
+        'expired' => array(
+            'label' => 'Transaction Expired',
+            'code' => 'holded',
+            'is_default' => 0
+        ),
+        'partial_refund' => array(
+            'label' => 'Partial Refund',
+            'code' => 'processing',
+            'is_default' => 0
+        ),
+        'partial_capture' => array(
+            'label' => 'Partial Capture',
+            'code' => 'processing',
+            'is_default' => 0
+        ),
+    );
+
+    try {
+        foreach ($statues as $status => $infos) {
+            $label = $infos['label'];
+            $code = $infos['code'];
+            $is_default = $infos['is_default'];
+
+            //Insert new Status in DB
+            $data[0] = array(
+                'status' => $status,
+                'label' => $label,
+            );
+
+            $installer->getConnection()->insertArray($statusTable, array('status', 'label'), $data);
+            //Insert relation between state and status
+            $data[0] = array(
+                'status' => $status,
+                'state' => $code,
+                'is_default' => $is_default,
+            );
+
+            $installer->getConnection()->insertArray(
+                $statusStateTable,
+                array('status', 'state', 'is_default'),
+                $data
+            );
+        }
+    } catch (Exception $ex) {
+        //Most likely integrity constraint violation. May happen if all setup scripts are run together (including the
+        //ones in the Magento core) on a Magento version at least equal to 1.6.0
+    }
+}
+
+$installer->endSetup();

--- a/src/app/code/community/Allopass/Hipay/sql/allopass_hipay_setup/mysql4-install-0.1.0.php
+++ b/src/app/code/community/Allopass/Hipay/sql/allopass_hipay_setup/mysql4-install-0.1.0.php
@@ -2,44 +2,8 @@
 
 $installer = $this;
 
-
-
 $installer->startSetup();
 
-$currentVersion = Mage::getVersion();
-if (version_compare($currentVersion, '1.4.2') == 1)
-{
-	
-	$statusTable        = $installer->getTable('sales/order_status');
-	$statusStateTable   = $installer->getTable('sales/order_status_state');
-	$statusLabelTable   = $installer->getTable('sales/order_status_label');
-	
-	$status = 'pending_capture';
-	$label = 'Pending Capture';
-	$code = "processing";
-	
-	//Insert new Status in DB
-	$data[0] = array(
-        'status'    => $status,
-        'label'     => $label,
-    );
-	
-	$installer->getConnection()->insertArray($statusTable, array('status', 'label'), $data);
-	//Insert relation between state and status
-	$data[0] = array(
-					'status'    => $status,
-					'state'     => $code,
-					'is_default'=> 0,
-				);
-
-	$installer->getConnection()->insertArray(
-			$statusStateTable,
-			array('status', 'state', 'is_default'),
-			$data
-	);
-}
- 
-
+//Moved to corresponding data script
 
 $installer->endSetup();
-

--- a/src/app/code/community/Allopass/Hipay/sql/allopass_hipay_setup/mysql4-upgrade-0.1.2-0.1.3.php
+++ b/src/app/code/community/Allopass/Hipay/sql/allopass_hipay_setup/mysql4-upgrade-0.1.2-0.1.3.php
@@ -2,71 +2,8 @@
 
 $installer = $this;
 
-
 $installer->startSetup();
 
-$currentVersion = Mage::getVersion();
-if (version_compare($currentVersion, '1.4.2') == 1)
-{
-	
-
-	$statusTable        = $installer->getTable('sales/order_status');
-	$statusStateTable   = $installer->getTable('sales/order_status_state');
-	$statusLabelTable   = $installer->getTable('sales/order_status_label');
-	
-	$status = 'capture_requested';
-	$label = 'Capture Requested';
-	$code = "processing";
-	
-	//Insert new Status in DB
-	$data[0] = array(
-        'status'    => $status,
-        'label'     => $label,
-    );
-	
-	$installer->getConnection()->insertArray($statusTable, array('status', 'label'), $data);
-	//Insert relation between state and status
-	$data[0] = array(
-					'status'    => $status,
-					'state'     => $code,
-					'is_default'=> 0,
-				);
-
-	$installer->getConnection()->insertArray(
-			$statusStateTable,
-			array('status', 'state', 'is_default'),
-			$data
-	);
-	
-	$status = 'refund_requested';
-	$label = 'Refund Requested';
-	$code = "processing";
-	
-	//Insert new Status in DB
-	$data[0] = array(
-			'status'    => $status,
-			'label'     => $label,
-	);
-	
-	$installer->getConnection()->insertArray($statusTable, array('status', 'label'), $data);
-	//Insert relation between state and status
-	$data[0] = array(
-			'status'    => $status,
-			'state'     => $code,
-			'is_default'=> 0,
-	);
-	
-	$installer->getConnection()->insertArray(
-			$statusStateTable,
-			array('status', 'state', 'is_default'),
-			$data
-	);
-	
-	
-	
-}
- 
-
+//Moved to corresponding data script
 
 $installer->endSetup();
-

--- a/src/app/code/community/Allopass/Hipay/sql/allopass_hipay_setup/mysql4-upgrade-1.0.9-1.1.0.php
+++ b/src/app/code/community/Allopass/Hipay/sql/allopass_hipay_setup/mysql4-upgrade-1.0.9-1.1.0.php
@@ -2,68 +2,8 @@
 
 $installer = $this;
 
-
 $installer->startSetup();
 
-$currentVersion = Mage::getVersion();
-if (version_compare($currentVersion, '1.4.2') == 1)
-{
-	
-
-	$statusTable        = $installer->getTable('sales/order_status');
-	$statusStateTable   = $installer->getTable('sales/order_status_state');
-	$statusLabelTable   = $installer->getTable('sales/order_status_label');
-	
-	$statues = array('authorization_requested'=>
-									array('label'=>'Authorization Requested',
-											'code'=>'processing',
-											'is_default'=>0
-									),
-					 'expired' => array('label'=>'Transaction Expired',
-										'code'=>'holded',
-										'is_default'=>0
-									),
-					 'partial_refund'=> array('label'=>'Partial Refund',
-										'code'=>'processing',
-										'is_default'=>0
-									),
-					'partial_capture'=> array('label'=>'Partial Capture',
-							'code'=>'processing',
-							'is_default'=>0
-					),
-	);
-	
-	foreach ($statues as $status=>$infos)
-	{
-		$label = $infos['label'];
-		$code = $infos['code'];
-		$is_default = $infos['is_default'];
-		
-		//Insert new Status in DB
-		$data[0] = array(
-				'status'    => $status,
-				'label'     => $label,
-		);
-		
-		$installer->getConnection()->insertArray($statusTable, array('status', 'label'), $data);
-		//Insert relation between state and status
-		$data[0] = array(
-				'status'    => $status,
-				'state'     => $code,
-				'is_default'=> $is_default,
-		);
-		
-		$installer->getConnection()->insertArray(
-				$statusStateTable,
-				array('status', 'state', 'is_default'),
-				$data
-		);
-	}
-	
-	
-}
- 
-
+//Moved to corresponding data script
 
 $installer->endSetup();
-

--- a/src/app/etc/modules/Allopass_Hipay.xml
+++ b/src/app/etc/modules/Allopass_Hipay.xml
@@ -4,6 +4,9 @@
 		<Allopass_Hipay>
 			<active>true</active>
 			<codePool>community</codePool>
+			<depends>
+				<Mage_Sales />
+			</depends>
 		</Allopass_Hipay>
 	</modules>
 </config>


### PR DESCRIPTION
When I tried to run our test suite on a project after installing this module, I encoutered a problem. Our test system builds the database by running all setup scripts, including all of the Magento core scripts plus all module scripts.
I found that 3 scripts from this module did not behave correctly in this situation, specifically they caused a Magento upgrade script to fail when it tries to create all order statuses according to the configuration. This should only happen with Magento 1.6 and above.

I'll explain a little better what happens:
1) when executing update scripts, Magento always runs "sql" scripts before "data" scripts. As such this module's scripts run before Magento's Mage/Sales/data/sales/setup/data-install-1.6.0.0.php. Therefore the Allopass Hipay module's scripts create a few order statuses in the sales_order_status table, which is otherwise empty;
2) later Magento runs the aforementioned script that tries to create all statuses that are defined in the configuration xml. This tries to create the same statuses again, resulting in a DB constraint violation.

Notice that, as I said, this only happens when one tries to run all install and update scripts at once.

To fix this I ensured that this module's scripts are run after the Magento scripts. To do so I:
1) moved the 3 offending scripts from the "sql" folder to the "data" folder, as there is no way to run a sql script after a data script;
2) added some try/catch instructions to suppress the errors that would happen when these scripts are executed on a database that already contains the order statuses they want to create;
3) modified the Allopass_Hipay.xml file to add a dependency to the Mage_Sales module. This ensures that the Allopass_Hipay scripts are executed after the Mage_Sales ones, plus it seems to me that even semantically this dependency makes sense;
4) modified the gitignore file because a rule excluded any "data" folder.

Wrom what I could see this works both on an empty DB when executing all scripts and also on a database that is already created and where only this module's scripts run. So it should be perfectly safe for everyone.