### PR TITLE
Correction notice validation commande

### DIFF
--- a/src/app/code/community/Allopass/Hipay/Model/Api/Formatter/ThreeDS/AccountInfoFormatter.php
+++ b/src/app/code/community/Allopass/Hipay/Model/Api/Formatter/ThreeDS/AccountInfoFormatter.php
@@ -145,7 +145,7 @@ class Allopass_Hipay_Model_Api_Formatter_ThreeDS_AccountInfoFormatter implements
                         /**
                          * @var Mage_Sales_Model_Order_Payment $payment
                          */
-                        if ($payment->getData('additional_information')['create_oneclick']) {
+                        if ($payment->getAdditionalInformation('create_oneclick')) {
                             $info->card_stored_24h++;
                         }
 


### PR DESCRIPTION
Lors de la validation de la commande, une notice est déclenchée sur l'inexistance de l'index "create_oneclick" dans la méthode `\Allopass_Hipay_Model_Api_Formatter_ThreeDS_AccountInfoFormatter::getPurchaseInfo`.

Il semblerait (suite à des tests faits avec xDebug) que nous rentrions de nombreuses fois dans le foreach `foreach ($payments->getItems() as $payment) { ... }` et que, aux premiers passage, cet index existe mais pas aux suivants, ce qui déclenche cette notice.

L'utilisation d'un `getAdditionalInformation` permet donc de retourner "null" si c'est le cas.