### PR TITLE
Fix undefined index create_oneclick

### DIFF
--- a/src/app/code/community/Allopass/Hipay/Model/Api/Formatter/ThreeDS/AccountInfoFormatter.php
+++ b/src/app/code/community/Allopass/Hipay/Model/Api/Formatter/ThreeDS/AccountInfoFormatter.php
@@ -145,7 +145,7 @@ class Allopass_Hipay_Model_Api_Formatter_ThreeDS_AccountInfoFormatter implements
                         /**
                          * @var Mage_Sales_Model_Order_Payment $payment
                          */
-                        if ($payment->getData('additional_information')['create_oneclick']) {
+                        if ($payment->getAdditionalInformation('create_oneclick')) {
                             $info->card_stored_24h++;
                         }
 


### PR DESCRIPTION
Il est possible d'avoir une Notice "Undefined index "create_oneclick"" sur la sauvegarde de commande.

Un simple passage de l'utilisation d'un `getData()` à un `getAdditionalInformation()` corrige le problème car cette méthode (qui n'est pas un getter magique) va d'abord vérifier la présence de cet index avant de le retourner.