### PR TITLE
Fix orders loading in 3DS account info formatter

### DIFF
--- a/src/app/code/community/Allopass/Hipay/Model/Api/Formatter/ThreeDS/AccountInfoFormatter.php
+++ b/src/app/code/community/Allopass/Hipay/Model/Api/Formatter/ThreeDS/AccountInfoFormatter.php
@@ -92,40 +92,9 @@ class Allopass_Hipay_Model_Api_Formatter_ThreeDS_AccountInfoFormatter implements
             $oneYearAgo = new \DateTime('1 years ago');
             $oneYearAgo = $oneYearAgo->format('Y-m-d H:i:s');
 
-            $orders = Mage::getResourceModel('sales/order_collection')
-                ->addAttributeToSelect('*')
-                ->addAttributeToFilter(
-                    'customer_id',
-                    $this->_order->getCustomerId()
-                )
-                ->addAttributeToFilter(
-                    'state',
-                    array('in' => Mage::getSingleton('sales/order_config')->getVisibleOnFrontStates())
-                );
-
-            $orders6Months = $orders
-                ->addAttributeToFilter(
-                    'created_at',
-                    array('gt' => $sixMonthAgo)
-                )
-                ->addAttributeToSort('created_at', 'desc')
-                ->load();
-
-            $orders24Hours = $orders
-                ->addAttributeToFilter(
-                    'created_at',
-                    array('gt' => $twentyFourHoursAgo)
-                )
-                ->addAttributeToSort('created_at', 'desc')
-                ->load();
-
-            $orders1Year = $orders
-                ->addAttributeToFilter(
-                    'created_at',
-                    array('gt' => $oneYearAgo)
-                )
-                ->addAttributeToSort('created_at', 'desc')
-                ->load();
+            $orders6Months = $this->getOrdersSince($sixMonthAgo);
+            $orders24Hours = $this->getOrdersSince($twentyFourHoursAgo);
+            $orders1Year = $this->getOrdersSince($oneYearAgo);
 
             // Substracting 1 to remove current order from the count
             $info->count = (int)($orders6Months->count() -1);
@@ -255,4 +224,28 @@ class Allopass_Hipay_Model_Api_Formatter_ThreeDS_AccountInfoFormatter implements
         return $info;
     }
 
+    /**
+     * @param string $sinceDate
+     * @return Mage_Sales_Model_Resource_Order_Collection
+     */
+    private function getOrdersSince(string $sinceDate)
+    {
+        return Mage::getResourceModel('sales/order_collection')
+            ->addAttributeToSelect('*')
+            ->addAttributeToFilter(
+                'customer_id',
+                $this->_order->getCustomerId()
+            )
+            ->addAttributeToFilter(
+                'state',
+                array('in' => Mage::getSingleton('sales/order_config')->getVisibleOnFrontStates())
+            )
+            ->addAttributeToFilter(
+                'created_at',
+                array('gt' => $sinceDate)
+            )
+            ->addAttributeToSort('created_at', 'desc')
+            ->load()
+        ;
+    }
 }


### PR DESCRIPTION
Using the same collection to load 3 different set of orders is wrong because Magento always use the firs loaded collection. Indeed with the previous code Magento was sending the count of orders in the last 6 month even for the last year orders count and the last 24 hours orders count.

Also note that the HiPay API limit the length of the last 24 hours orders count parameter to 3 characters length. So in a store where the same customer place more than 999 orders in 6 months he cannot pay anymore with the HiPay payment method.