### PR TITLE
Limit payment attempts 1y and 24h to 999

### DIFF
--- a/src/app/code/community/Allopass/Hipay/Model/Api/Formatter/ThreeDS/AccountInfoFormatter.php
+++ b/src/app/code/community/Allopass/Hipay/Model/Api/Formatter/ThreeDS/AccountInfoFormatter.php
@@ -129,8 +129,8 @@ class Allopass_Hipay_Model_Api_Formatter_ThreeDS_AccountInfoFormatter implements
 
             // Substracting 1 to remove current order from the count
             $info->count = (int)($orders6Months->count() -1);
-            $info->payment_attempts_1y = (int)($orders1Year->count() -1);
-            $info->payment_attempts_24h = (int)($orders24Hours->count() -1);
+            $info->payment_attempts_1y = min((int)($orders1Year->count() -1), 999);
+            $info->payment_attempts_24h = min((int)($orders24Hours->count() -1), 999);
 
             $info->card_stored_24h = 0;
 


### PR DESCRIPTION
It appears that HiPay API method `POST /v1/hpayment` has a limit of 3 characters on `account_info.purchase.payment_attempts_1y` and `account_info.purchase.payment_attempts_24h` fields.

For example see this cURL response:
```
curl -X POST "https://stage-secure-gateway.hipay-tpp.com/rest/v1/hpayment" -H "accept: application/json" -H "Authorization: Basic <SECRET>" -H "Content-Type: multipart/form-data" -F "house_extension=B" -F "account_info={ "customer": { "account_possession": 1, "account_change": 20180507, "opening_account_date": 20180507, "password_change": 20180507 }, "purchase": { "count": 2, "card_stored_24h": 0, "payment_attempts_24h": 0, "payment_attempts_1y": 1000 }, "payment": { "enrollment_date": 20180507 }, "shipping": { "shipping_used_date": 20180507, "address_usage_duration": 1, "name_indicator": 1, "suspicious_activity": 1 } }" -F "lastname=Doe" -F "gender=U" -F "streetaddress2=Immeuble B" -F "shipto_msisdn=3362345678" -F "css=https://developer.hipay.com/misc/simulator/css-responsive.css" -F "recurring_payment=0" -F "soft_descriptor=Dell Inspiron 15 3583 (i3583-3112BLK-PFR)" -F "decline_url=https://developer.hipay.com/simulator/decline/" -F "shipto_phone=33112345678" -F "basket=[{"european_article_numbering":"4711892728946","product_reference":"NF-a1690","name":"My first product","type":"good","quantity":1,"unit_price":8.99,"discount":0,"tax_rate":"8.20","total_amount":8.99}]" -F "shipto_zipcode=75001" -F "iban=FR1420041010050500013M02606" -F "operation=Authorization" -F "recipientinfo=Dr." -F "pending_url=https://developer.hipay.com/simulator/pending/" -F "payment_product_list=mastercard,visa,american-express" -F "authentication_indicator=0" -F "house_number=101" -F "http_user_agent=Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)" -F "prepaid_card_number=" -F "shipto_state=" -F "cardtoken=ef3b4d50325268e59d216c0b053a4f5c7eb559f9abeca0ef178ea1941b2d156a" -F "orderid=ORDER_1612363240145" -F "shipto_streetaddress=101 Rue de Rivoli" -F "shipto_gender=U" -F "shipto_streetaddress2=Immeuble B" -F "shipto_lastname=Doe" -F "exemption={}" -F "cancel_url=https://developer.hipay.com/simulator/cancel/" -F "request_id=2078323" -F "city=Paris" -F "expiration_limit=3" -F "eci=9" -F "tax=1.1" -F "delivery_method=CARRIER" -F "birthdate=19880612" -F "prepaid_card_security_code=" -F "national_identification_number=AA 01 23 44 B" -F "zipcode=75001" -F "shipto_country=FR" -F "phone=33012345678" -F "shipping=1.3" -F "bank_name=BNP" -F "sales_channel=" -F "recurring_info={ "expiration_date": 20180507, "frequency": 31 }" -F "shipto_house_number=101" -F "payment_connectivity=web" -F "currency=EUR" -F "state=" -F "streetaddress=101 Rue de Rivoli" -F "shipto_firstname=Cathy" -F "shipto_city=Paris" -F "tax_rate=1" -F "phone_operator=FASTWEB" -F "carrier_description=La Poste, 27 Rue des Francs Bourgeois" -F "qiwiuser=33670985712" -F "payment_product_category_list=credit-card" -F "merchant_risk_statement={ "email_delivery_address": "jane.doe@test.com", "delivery_time_frame": 1, "purchase_indicator": 1, "pre_order_date": 20190925, "reorder_indicator": 1, "shipping_indicator": 1, "gift_card": { "amount": 15, "count": 0, "currency": "EUR" } }" -F "country=FR" -F "amount=8.99" -F "ipaddr=127.0.0.1" -F "accept_url=https://developer.hipay.com/simulator/success/" -F "issuer_bank_id=BNPAFRPPXXX" -F "language=en_GB" -F "custom_data={"internal_reference":"ORD_987465","customer_first_order":true,"other_sample_parameter":"Other sample value"}" -F "delivery_date=2022-12-20" -F "long_description=A super long description here..." -F "notify_url=https://developer.hipay.com/simulator/notify/" -F "device_channel=1" -F "template=basic-js" -F "msisdn=33612345678" -F "time_limit_to_pay=1800" -F "source={"integration_version":"1.9.0","brand":"DEVPORTAL","source":"CSDK","brand_version":"12.2.0"}" -F "device_fingerprint=042q0aAXOogFCkNMNf94lis1ztsdwpJAn3AFS6wesUIr2q" -F "firstname=Cathy" -F "card_holder=Cathy Doe" -F "display_selector=1" -F "email=john.doe@foobar99.com" -F "description=A super short description here..." -F "order_category_code=5941" -F "previous_auth_info={ "transaction_reference": "800000987283" }" -F "cid=283749291" -F "http_accept=*\/*" -F "merchant_display_name=ACME Consolidated" -F "exception_url=https://developer.hipay.com/simulator/exception/" -F "shipto_recipientinfo=Dr." -F "website_id=STWAK4897048"

{
  "code": "1010502",
  "message": "The format of payment_attempts_1y field is invalid. Please respect the maximum length : 3.",
  "description": ""
}
```

With this PR a customer can pay with HiPay even if he placed more than 999 orders in a year (which could be the case on many B2B stores).
