### PR TITLE
Fix cancel pending orders loading

### DIFF
--- a/src/app/code/community/Allopass/Hipay/Model/Observer.php
+++ b/src/app/code/community/Allopass/Hipay/Model/Observer.php
@@ -49,7 +49,7 @@ class Allopass_Hipay_Model_Observer
             }
 
             $collection = Mage::getResourceModel('sales/order_collection');
-            $collection->addFieldToSelect(array('entity_id', 'increment_id', 'store_id', 'state'))
+            $collection
                 ->addFieldToFilter('main_table.state', Mage_Sales_Model_Order::STATE_NEW)
                 ->addFieldToFilter('op.method', array('eq' => $key))
                 ->addAttributeToFilter(


### PR DESCRIPTION
If order is not fully loaded could result in unexpected behavior during cancel (especially involving third party observers on `order_cancel_after` event). Therefore, there is no reason to limit fields of collection because orders are on a flat table so the performance gain is negligible.